### PR TITLE
fix(parser): Protect inline code from formatting while allowing spans

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -155,9 +155,22 @@ export class MarkdownParser {
     let html = text;
     // Order matters: parse code first to avoid conflicts
     html = this.parseInlineCode(html);
+    // Use placeholders to protect inline code while preserving formatting spans
+    const codeBlocks = new Map();
+    html = html.replace(/(<code>.*?<\/code>)/g, (match) => {
+      // Prevent conflicts with private use area Unicode
+      const placeholder = `\uE000${codeBlocks.size}\uE001`;
+      codeBlocks.set(placeholder, match);
+      return placeholder;
+    });
+    // Process other inline elements on text with placeholders
     html = this.parseLinks(html);
     html = this.parseBold(html);
     html = this.parseItalic(html);
+    // Restore code blocks
+    codeBlocks.forEach((codeBlock, placeholder) => {
+      html = html.replace(placeholder, codeBlock);
+    });
     return html;
   }
 

--- a/test/overtype.test.js
+++ b/test/overtype.test.js
@@ -198,6 +198,166 @@ This is **bold** and *italic*.
   assert(actual.includes('class="raw-line"'), 'Raw line display', 'Should show raw line for active line');
 })();
 
+// Test: Inline code with underscores and stars
+(() => {
+  const tests = [
+    { 
+      input: '`OP_CAT_DOG`', 
+      expected: '<div><code><span class="syntax-marker">`</span>OP_CAT_DOG<span class="syntax-marker">`</span></code></div>',
+      description: 'Should not italicize underscores inside code'
+    },
+    { 
+      input: '`OP_CAT` and *dog*', 
+      expected: '<div><code><span class="syntax-marker">`</span>OP_CAT<span class="syntax-marker">`</span></code> and <em><span class="syntax-marker">*</span>dog<span class="syntax-marker">*</span></em></div>',
+      description: 'Should italicize outside code but not inside'
+    },
+    { 
+      input: '`function_name_here` _should work_', 
+      expected: '<div><code><span class="syntax-marker">`</span>function_name_here<span class="syntax-marker">`</span></code> <em><span class="syntax-marker">_</span>should work<span class="syntax-marker">_</span></em></div>',
+      description: 'Should handle mixed code and italic with underscores'
+    },
+    { 
+      input: '`__init__` method', 
+      expected: '<div><code><span class="syntax-marker">`</span>__init__<span class="syntax-marker">`</span></code> method</div>',
+      description: 'Should not bold double underscores inside code'
+    },
+    { 
+      input: 'Text `with_code` and **bold**', 
+      expected: '<div>Text <code><span class="syntax-marker">`</span>with_code<span class="syntax-marker">`</span></code> and <strong><span class="syntax-marker">**</span>bold<span class="syntax-marker">**</span></strong></div>',
+      description: 'Should handle code with underscores and separate bold'
+    },
+    { 
+      input: '`*asterisk*` and _underscore_', 
+      expected: '<div><code><span class="syntax-marker">`</span>*asterisk*<span class="syntax-marker">`</span></code> and <em><span class="syntax-marker">_</span>underscore<span class="syntax-marker">_</span></em></div>',
+      description: 'Should not italicize asterisks inside code'
+    }
+  ];
+
+  tests.forEach(test => {
+    const actual = MarkdownParser.parseLine(test.input);
+    assert(htmlEqual(actual, test.expected), `Inline code protection: ${test.input}`, `${test.description}. Expected: ${test.expected}, Got: ${actual}`);
+  });
+})();
+
+// Test: Formatting that spans across code blocks
+(() => {
+  const tests = [
+    { 
+      input: '*cat `test` dog*', 
+      expected: '<div><em><span class="syntax-marker">*</span>cat <code><span class="syntax-marker">`</span>test<span class="syntax-marker">`</span></code> dog<span class="syntax-marker">*</span></em></div>',
+      description: 'Should italicize text that spans across code blocks'
+    },
+    { 
+      input: '**bold `code_here` more bold**', 
+      expected: '<div><strong><span class="syntax-marker">**</span>bold <code><span class="syntax-marker">`</span>code_here<span class="syntax-marker">`</span></code> more bold<span class="syntax-marker">**</span></strong></div>',
+      description: 'Should bold text that spans across code blocks'
+    },
+    { 
+      input: '_italic `with_underscores` still italic_', 
+      expected: '<div><em><span class="syntax-marker">_</span>italic <code><span class="syntax-marker">`</span>with_underscores<span class="syntax-marker">`</span></code> still italic<span class="syntax-marker">_</span></em></div>',
+      description: 'Should handle italic with underscores spanning code'
+    },
+    { 
+      input: '__bold `code` and `more_code` bold__', 
+      expected: '<div><strong><span class="syntax-marker">__</span>bold <code><span class="syntax-marker">`</span>code<span class="syntax-marker">`</span></code> and <code><span class="syntax-marker">`</span>more_code<span class="syntax-marker">`</span></code> bold<span class="syntax-marker">__</span></strong></div>',
+      description: 'Should bold text spanning multiple code blocks'
+    }
+  ];
+
+  tests.forEach(test => {
+    const actual = MarkdownParser.parseLine(test.input);
+    assert(htmlEqual(actual, test.expected), `Spanning code: ${test.input}`, `${test.description}. Expected: ${test.expected}, Got: ${actual}`);
+  });
+})();
+
+// Test: Multiple inline code blocks with external formatting
+(() => {
+  const tests = [
+    { 
+      input: '`first_code` and `second_code` with *italic*', 
+      expected: '<div><code><span class="syntax-marker">`</span>first_code<span class="syntax-marker">`</span></code> and <code><span class="syntax-marker">`</span>second_code<span class="syntax-marker">`</span></code> with <em><span class="syntax-marker">*</span>italic<span class="syntax-marker">*</span></em></div>',
+      description: 'Should handle multiple code blocks with external formatting'
+    },
+    { 
+      input: '*Before `__code__` between `_more_code_` after*', 
+      expected: '<div><em><span class="syntax-marker">*</span>Before <code><span class="syntax-marker">`</span>__code__<span class="syntax-marker">`</span></code> between <code><span class="syntax-marker">`</span>_more_code_<span class="syntax-marker">`</span></code> after<span class="syntax-marker">*</span></em></div>',
+      description: 'Should handle italic spanning multiple protected code blocks'
+    },
+    { 
+      input: '**Text `code1` middle `code2` end**', 
+      expected: '<div><strong><span class="syntax-marker">**</span>Text <code><span class="syntax-marker">`</span>code1<span class="syntax-marker">`</span></code> middle <code><span class="syntax-marker">`</span>code2<span class="syntax-marker">`</span></code> end<span class="syntax-marker">**</span></strong></div>',
+      description: 'Should bold across multiple code blocks'
+    }
+  ];
+
+  tests.forEach(test => {
+    const actual = MarkdownParser.parseLine(test.input);
+    assert(htmlEqual(actual, test.expected), `Multiple code + format: ${test.input}`, `${test.description}. Expected: ${test.expected}, Got: ${actual}`);
+  });
+})();
+
+// Test: Complex nested scenarios
+(() => {
+  const tests = [
+    { 
+      input: 'Normal `code_block` and **bold `with_code` bold** text', 
+      expected: '<div>Normal <code><span class="syntax-marker">`</span>code_block<span class="syntax-marker">`</span></code> and <strong><span class="syntax-marker">**</span>bold <code><span class="syntax-marker">`</span>with_code<span class="syntax-marker">`</span></code> bold<span class="syntax-marker">**</span></strong> text</div>',
+      description: 'Should handle mixed standalone and spanning formatting'
+    },
+    { 
+      input: '*italic* `code_here` **bold `spanning_code` bold**', 
+      expected: '<div><em><span class="syntax-marker">*</span>italic<span class="syntax-marker">*</span></em> <code><span class="syntax-marker">`</span>code_here<span class="syntax-marker">`</span></code> <strong><span class="syntax-marker">**</span>bold <code><span class="syntax-marker">`</span>spanning_code<span class="syntax-marker">`</span></code> bold<span class="syntax-marker">**</span></strong></div>',
+      description: 'Should handle multiple different formatting types with code'
+    },
+    {
+      input: '[Link `with_code` text](url) and `regular_code`',
+      expected: '<div><a href="url"><span class="syntax-marker">[</span>Link <code><span class="syntax-marker">`</span>with_code<span class="syntax-marker">`</span></code> text<span class="syntax-marker">](</span><span class="syntax-marker">url</span><span class="syntax-marker">)</span></a> and <code><span class="syntax-marker">`</span>regular_code<span class="syntax-marker">`</span></code></div>',
+      description: 'Should handle links spanning code blocks'
+    }
+  ];
+
+  tests.forEach(test => {
+    const actual = MarkdownParser.parseLine(test.input);
+    assert(htmlEqual(actual, test.expected), `Complex nested code: ${test.input}`, `${test.description}. Expected: ${test.expected}, Got: ${actual}`);
+  });
+})();
+
+// Test: Edge cases that should NOT be formatted
+(() => {
+  const tests = [
+    { 
+      input: '`**not_bold**`', 
+      expected: '<div><code><span class="syntax-marker">`</span>**not_bold**<span class="syntax-marker">`</span></code></div>',
+      description: 'Should not process bold markers inside code'
+    },
+    { 
+      input: '`__also_not_bold__`', 
+      expected: '<div><code><span class="syntax-marker">`</span>__also_not_bold__<span class="syntax-marker">`</span></code></div>',
+      description: 'Should not process underscore bold markers inside code'
+    },
+    { 
+      input: '`*not_italic*`', 
+      expected: '<div><code><span class="syntax-marker">`</span>*not_italic*<span class="syntax-marker">`</span></code></div>',
+      description: 'Should not process asterisk italic markers inside code'
+    },
+    { 
+      input: '`_not_italic_`', 
+      expected: '<div><code><span class="syntax-marker">`</span>_not_italic_<span class="syntax-marker">`</span></code></div>',
+      description: 'Should not process underscore italic markers inside code'
+    },
+    {
+      input: '`[not_a_link](url)`',
+      expected: '<div><code><span class="syntax-marker">`</span>[not_a_link](url)<span class="syntax-marker">`</span></code></div>',
+      description: 'Should not process link markers inside code'
+    }
+  ];
+
+  tests.forEach(test => {
+    const actual = MarkdownParser.parseLine(test.input);
+    assert(htmlEqual(actual, test.expected), `Code protection edge cases: ${test.input}`, `${test.description}. Expected: ${test.expected}, Got: ${actual}`);
+  });
+})();
+
 // ===== Integration Tests =====
 console.log('\n🔧 Integration Tests\n');
 


### PR DESCRIPTION
This fixes issue #2. Previously, links, bold, and italic HTML was sometimes incorrectly applied to inline code containing a special character. For example, `__init__` should not be bolded, but it currently is.

At the same time, formatting that spans across inline code should still be applied. The fix is to replace code blocks with a unique placeholder that is unlikely to appear in the text.

This PR replaces each code block with indexed private use area unicode (`\uE000{index}\uE001`) and then applies link, bold, and italic formatting. When finished, the placeholder is replaced with the corresponding code block.

(The PR includes comprehensive test coverage for edge cases including nested formatting, multiple code blocks, and complex spanning scenarios)

Before:

<img width="127" height="41" alt="Screenshot 2025-08-17 at 6 51 14 PM" src="https://github.com/user-attachments/assets/d5f052db-01f9-495b-92f3-60d2fe163da4" />
<img width="133" height="35" alt="Screenshot 2025-08-17 at 6 52 46 PM" src="https://github.com/user-attachments/assets/167f086b-dec6-4837-b170-f316bb33fc72" />
<img width="186" height="38" alt="Screenshot 2025-08-17 at 6 54 37 PM" src="https://github.com/user-attachments/assets/46c96f3b-b06b-431e-993e-0ef832bf322c" />


After:

<img width="113" height="37" alt="Screenshot 2025-08-17 at 6 51 34 PM" src="https://github.com/user-attachments/assets/ae04079d-6dd6-49d4-9a21-0c7a8a7a8a57" />
<img width="122" height="34" alt="Screenshot 2025-08-17 at 6 52 26 PM" src="https://github.com/user-attachments/assets/bdac433d-21b0-4d16-bc35-7973bb73f11e" />
<img width="178" height="37" alt="Screenshot 2025-08-17 at 6 54 17 PM" src="https://github.com/user-attachments/assets/58b4e013-a711-46b2-95ab-919312f854eb" />
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Protects inline code from being formatted while still allowing bold/italic/link spans across code. Fixes incorrect styling like __init__ being bolded inside code (fixes #2).

- **Bug Fixes**
  - Wraps each rendered code block in a unique Private Use Area placeholder, parses links/bold/italic, then restores the code block.
  - Blocks formatting inside code but preserves formatting that spans across code segments.
  - Adds tests for nested formatting, multiple code blocks, and spanning scenarios.

<!-- End of auto-generated description by cubic. -->

