### PR TITLE
Add type declaration file for TypeScript users

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/overtype.js",
   "module": "dist/overtype.esm.js",
   "unpkg": "dist/overtype.min.js",
+  "types": "src/overtype.d.ts",
   "type": "module",
   "scripts": {
     "build": "node build.js",

--- a/src/overtype.d.ts
+++ b/src/overtype.d.ts
@@ -1,0 +1,77 @@
+export type Theme = {
+    name: string;
+    colors: {
+        bgPrimary?: string;
+        bgSecondary?: string;
+        text?: string;
+        h1?: string;
+        h2?: string;
+        h3?: string;
+        strong?: string;
+        em?: string;
+        link?: string;
+        code?: string;
+        codeBg?: string;
+        blockquote?: string;
+        hr?: string;
+        syntaxMarker?: string;
+        cursor?: string;
+        selection?: string;
+    }
+}
+
+export type Stats = {
+    words: number;
+    chars: number;
+    lines: number;
+    line: number;
+    column: number;
+}
+
+export type Options = {
+    fontSize?: string;
+    lineHeight?: string;
+    fontFamily?: string;
+    padding?: string;
+    theme?: string | Theme;
+    colors?: Theme['colors'];
+    mobile?: {
+        fontSize?: string;
+        padding?: string;
+        lineHeight?: string;
+    }
+    autofocus?: boolean;
+    placeholder?: string;
+    value?: string;
+    showStats?: boolean;
+    statsFormatter?: (stats: Stats) => string;
+    toolbar?: boolean;
+    onChange?: (value: string, instance: Editor) => void;
+    onKeydown?: (event: KeyboardEvent, instance: Editor) => void;
+}
+
+export type Editor = {
+    blur: () => void;
+    destroy: () => void;
+    focus: () => void;
+    getValue: () => string;
+    isInitialized: () => boolean;
+    reinit(options: Options): void;
+    setTheme: (theme: string | Theme) => void;
+    setValue: (value: string) => void;
+    showStats: (show: boolean) => void;
+}
+
+interface OverTypeModule {
+    destroyAll: () => void;
+    getInstance: (element: HTMLElement) => Editor | null;
+    init: (target: string, options?: Options) => Editor[];
+    new(target: string, options?: Options): Editor[];
+    setTheme: (theme: string | Theme, overrides: Theme['colors']) => void;
+    themes: {
+        'solar': Theme;
+        'cave': Theme;
+    }
+}
+declare const OverType: OverTypeModule
+export default OverType

--- a/src/overtype.d.ts
+++ b/src/overtype.d.ts
@@ -62,11 +62,14 @@ export type Editor = {
     showStats: (show: boolean) => void;
 }
 
+
+type Target = string | HTMLElement | NodeList | HTMLElement[]
+
 interface OverTypeModule {
     destroyAll: () => void;
     getInstance: (element: HTMLElement) => Editor | null;
-    init: (target: string, options?: Options) => Editor[];
-    new(target: string, options?: Options): Editor[];
+    init: (target: Target, options?: Options) => Editor[];
+    new(target: Target, options?: Options): Editor[];
     setTheme: (theme: string | Theme, overrides: Theme['colors']) => void;
     themes: {
         'solar': Theme;


### PR DESCRIPTION
Without type definitions, users who wish to use this library in their TypeScript project get build errors and no type checking. This PR adds a simple type declaration file and registers it in `package.json`.

Manually making these changes to the installed package in `node_modules` confirms that it works:

<img width="284" height="28" alt="image" src="https://github.com/user-attachments/assets/2001a92b-272e-4404-8999-5ee9edeb0f30" />

<img width="782" height="294" alt="image" src="https://github.com/user-attachments/assets/adb6c8a7-a7eb-4a9e-aa2f-d9505a07a151" />
