### PR TITLE
fix(parser): Detect inline code with multiple inner backticks

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -151,10 +151,9 @@ export class MarkdownParser {
     // Regex explainer:
     // (?<!`): A negative lookbehind ensuring the opening backticks are not preceded by another backtick.
     // (`+): A capturing group that matches and remembers the opening sequence of one or more backticks. This is Group 1.
-    // ((?:(?!\1).)+?): A capturing group that greedily matches any character that is not the exact sequence of backticks captured in Group 1. This is Group 2.
+    // (.*?)(?=(?<!`)\1(?!`)): A capturing group that matches any character until the exact sequence of backticks captured in Group 1 is found, with no backticks before or after. This is Group 2.
     // (\1): A backreference to Group 1, ensuring the closing sequence has the exact same number of backticks as the opening sequence. This is Group 3.
-    // (?!`): A negative lookahead ensuring the closing backticks are not followed by another backtick.
-    return html.replace(/(?<!`)(`+)(?!`)((?:(?!\1).)+?)(\1)(?!`)/g, '<code><span class="syntax-marker">$1</span>$2<span class="syntax-marker">$3</span></code>');
+    return html.replace(/(?<!`)(`+)(?!`)(.*?)(?=(?<!`)\1(?!`))(\1)/g, '<code><span class="syntax-marker">$1</span>$2<span class="syntax-marker">$3</span></code>');
   }
 
   /**

--- a/test/overtype.test.js
+++ b/test/overtype.test.js
@@ -376,6 +376,7 @@ This is **bold** and *italic*.
 (() => {
   const tests = [
     { input: '``code with `backtick` inside``', expected: '<div><code><span class="syntax-marker">``</span>code with `backtick` inside<span class="syntax-marker">``</span></code></div>' },
+    { input: '`code with ``multi-backtick`` inside`', expected: '<div><code><span class="syntax-marker">`</span>code with ``multi-backtick`` inside<span class="syntax-marker">`</span></code></div>' },
     { input: '`single` and ``double``', expected: '<div><code><span class="syntax-marker">`</span>single<span class="syntax-marker">`</span></code> and <code><span class="syntax-marker">``</span>double<span class="syntax-marker">``</span></code></div>' },
     { input: '```triple```', expected: '<div><code><span class="syntax-marker">```</span>triple<span class="syntax-marker">```</span></code></div>' },
     { input: '`unmatched``', expected: '<div>`unmatched``</div>' },


### PR DESCRIPTION
Currently, the parser fails to detect inline code that has multiple consecutive inner backticks (ex: `multiple ``inner`` backticks`). This was an oversight on my part in PR #19 , as I failed to consider this edge case.

The solution is fairly simple. Instead of preventing any occurrence of the starting backtick sequence inside the code span, we match until we find the proper terminating sequence, one that matches the opener exactly without preceding or subsequent backticks.

Old regex: ``(?<!`)(`+)(?!`)((?:(?!\1).)+?)(\1)(?!`)``

New regex: ``(?<!`)(`+)(?!`)(.*?)(?=(?<!`)\1(?!`))(\1)``

Before:

<img width="282" height="47" alt="Screenshot 2025-08-20 at 11 39 08 AM" src="https://github.com/user-attachments/assets/1c5ad759-c0b0-4452-b5c4-d5ff00198dd6" />

After:

<img width="282" height="40" alt="Screenshot 2025-08-20 at 11 38 56 AM" src="https://github.com/user-attachments/assets/8e32e75c-660e-4eb0-be7a-114453ed1b9d" />

