### PR TITLE
Add strikethrough syntax support (GFM extension)

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -140,6 +140,20 @@ export class MarkdownParser {
   }
 
   /**
+   * Parse strikethrough text
+   * Supports both single (~) and double (~~) tildes, but rejects 3+ tildes
+   * @param {string} html - HTML with potential strikethrough markdown
+   * @returns {string} HTML with strikethrough styling
+   */
+  static parseStrikethrough(html) {
+    // Double tilde strikethrough: ~~text~~ (but not if part of 3+ tildes)
+    html = html.replace(/(?<!~)~~(?!~)(.+?)(?<!~)~~(?!~)/g, '<del><span class="syntax-marker">~~</span>$1<span class="syntax-marker">~~</span></del>');
+    // Single tilde strikethrough: ~text~ (but not if part of 2+ tildes on either side)
+    html = html.replace(/(?<!~)~(?!~)(.+?)(?<!~)~(?!~)/g, '<del><span class="syntax-marker">~</span>$1<span class="syntax-marker">~</span></del>');
+    return html;
+  }
+
+  /**
    * Parse inline code
    * @param {string} html - HTML with potential code markdown
    * @returns {string} HTML with code styling
@@ -246,6 +260,7 @@ export class MarkdownParser {
     });
     
     // Process other inline elements on text with placeholders
+    html = this.parseStrikethrough(html);
     html = this.parseBold(html);
     html = this.parseItalic(html);
     

--- a/src/styles.js
+++ b/src/styles.js
@@ -325,6 +325,14 @@ export function generateStyles(options = {}) {
       font-style: italic !important;
     }
 
+    /* Strikethrough text */
+    .overtype-wrapper .overtype-preview del {
+      color: var(--del, #ee964b) !important;
+      text-decoration: line-through !important;
+      text-decoration-color: var(--del, #ee964b) !important;
+      text-decoration-thickness: 1px !important;
+    }
+
     /* Inline code */
     .overtype-wrapper .overtype-preview code {
       background: var(--code-bg, rgba(244, 211, 94, 0.4)) !important;


### PR DESCRIPTION

<img width="1906" height="966" alt="スクリーンショット 2025-08-23 昼3 28 22" src="https://github.com/user-attachments/assets/5899e335-5f1d-4f1f-85e0-336bdf8ac521" />



---


## Summary by cubic
Add GitHub Flavored Markdown strikethrough (~ and ~~) to the parser and style <del> elements in the preview. Integrates cleanly with existing inline parsing and preserves code span safety.

- **New Features**
  - Added parseStrikethrough() supporting single and double tildes; ignores 3+ tildes.
  - Integrated before bold/italic in the inline pipeline; code spans remain protected.
  - Added themed styles for del (color, line-through, thickness).
  - Expanded tests for edge cases: triple tildes ignored, no parsing inside code, and mixing with bold/italic/links/headers.

<!-- End of auto-generated description by cubic. -->

