### PR TITLE
Add support for configuring toolbar buttons

### DIFF
--- a/src/overtype.js
+++ b/src/overtype.js
@@ -104,7 +104,7 @@ class OverType {
 
       // Setup toolbar if enabled
       if (this.options.toolbar) {
-        this.toolbar = new Toolbar(this);
+        this.toolbar = new Toolbar(this, this.options.toolbar.buttons);
         this.toolbar.create();
         
         // Update toolbar states on selection change

--- a/src/toolbar.js
+++ b/src/toolbar.js
@@ -7,10 +7,11 @@ import * as icons from './icons.js';
 import * as markdownActions from 'markdown-actions';
 
 export class Toolbar {
-  constructor(editor) {
+  constructor(editor, buttonConfig = null) {
     this.editor = editor;
     this.container = null;
     this.buttons = {};
+    this.buttonConfig = buttonConfig
   }
 
   /**
@@ -24,7 +25,7 @@ export class Toolbar {
     this.container.setAttribute('aria-label', 'Text formatting');
 
     // Define toolbar buttons
-    const buttonConfig = [
+    const buttonConfig = this.buttonConfig ?? [
       { name: 'bold', icon: icons.boldIcon, title: 'Bold (Ctrl+B)', action: 'toggleBold' },
       { name: 'italic', icon: icons.italicIcon, title: 'Italic (Ctrl+I)', action: 'toggleItalic' },
       { separator: true },


### PR DESCRIPTION
Awesome library! While using it, i noticed that there was no clear API for configuring the toolbar buttons. I started on a possible way to solve this, by adding an options `toolbar.buttons` config. This should provide backwards compatibility, so the OverType option can either look like:

```ts
// current
new OverType(element, {
	toolbar: true
}
```

or

```ts
// with config
new OverType(element, {
	toolbar: {
		buttons: [/* array of buttons */]
	}
}
```

But before implementing much, i wanted to raise a discussion on how the button configs should be exposed. Should just the individual buttons + separators be exposed, or should it be possible to configure things like the icon, title, name etc. as well?
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Adds configurable toolbar buttons via options.toolbar.buttons. Keeps the existing toolbar: true API and defaults to the current button set.

- **New Features**
  - OverType forwards options.toolbar.buttons to Toolbar; Toolbar uses it or falls back to defaults.
  - Allows custom ordering, subsets, and separators without breaking existing setups.

<!-- End of auto-generated description by cubic. -->

