### PR TITLE
fix: escaped twice issue of links

### DIFF
--- a/src/parser.js
+++ b/src/parser.js
@@ -355,7 +355,7 @@ export class MarkdownParser {
         // URL should NOT be processed for markdown - use it as-is
         const anchorName = `--link-${this.linkIndex++}`;
         const safeUrl = this.sanitizeUrl(sanctuary.url);
-        replacement = `<a href="${safeUrl}" style="anchor-name: ${anchorName}"><span class="syntax-marker">[</span>${processedLinkText}<span class="syntax-marker url-part">](${this.escapeHtml(sanctuary.url)})</span></a>`;
+        replacement = `<a href="${safeUrl}" style="anchor-name: ${anchorName}"><span class="syntax-marker">[</span>${processedLinkText}<span class="syntax-marker url-part">](${sanctuary.url})</span></a>`;
       }
       
       html = html.replace(placeholder, replacement);


### PR DESCRIPTION
try to fix #63 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix double-escaping of link URLs in the Markdown parser so the displayed URL isn’t escaped twice. The anchor href remains sanitized; resolves #63.

<!-- End of auto-generated description by cubic. -->

