### PR TITLE
adds public methods to show / hide the toolbar

### DIFF
--- a/src/overtype-webcomponent.js
+++ b/src/overtype-webcomponent.js
@@ -670,6 +670,18 @@ class OverTypeEditor extends HTMLElement {
   getEditor() {
     return this._editor;
   }
+
+  showToolbar() {
+    if (this._editor) {
+      this._editor.showToolbar();
+    }
+  }
+
+  hideToolbar() {
+    if (this._editor) {
+      this._editor.hideToolbar();
+    }
+  }
 }
 
 // Register the custom element

--- a/src/overtype.js
+++ b/src/overtype.js
@@ -1016,6 +1016,30 @@ class OverType {
       this.updatePreview();
     }
 
+    
+    /**
+     * reveal the toolbar if it is hidden
+     * create it if it does not exist
+     * @returns {void}
+     */
+    showToolbar(){
+      if (this.toolbar) {
+        this.toolbar.show();
+      } else {
+        this._createToolbar();
+      }
+    }
+
+    /**
+     * hide the toolbar if it exists
+     * @returns {void}
+     */
+    hideToolbar(){
+      if (this.toolbar) {
+        this.toolbar.hide();
+      }
+    }
+
     /**
      * Set theme for this instance
      * @param {string|Object} theme - Theme name or custom theme object

--- a/src/toolbar.js
+++ b/src/toolbar.js
@@ -288,6 +288,27 @@ export class Toolbar {
   }
 
   /**
+   * Show the toolbar
+   */
+  show() {
+    if (this.container) {
+      this.container.classList.add('overtype-toolbar');
+      this.container.style.display = '';
+    }
+  }
+
+  /**
+   * Hide the toolbar, but do not destroy it
+   */
+  hide() {
+    if (this.container) {
+      this.container.style.display = 'none';
+      // .overtype-toolbar will override display:none, so we remove it
+      this.container.classList.remove('overtype-toolbar');
+    }
+  }
+
+  /**
    * Destroy toolbar and cleanup
    */
   destroy() {

--- a/test/webcomponent.test.js
+++ b/test/webcomponent.test.js
@@ -467,5 +467,34 @@ setTimeout(() => {
       }
     }, 100);
   });
+
+
+  runTest('Show / hide toolbar programmatically via API', () => {
+    const container = dom.window.document.getElementById('test-container');
+    const editor = dom.window.document.createElement('overtype-editor');
+    container.appendChild(editor);
+
+    setTimeout(() => {
+
+      // Initially no toolbar
+      let instance = editor.getEditor();
+      if (instance.toolbar) throw new Error('Toolbar should not be present initially');
+
+      // Show toolbar
+      editor.showToolbar();
+      instance = editor.getEditor();
+      if (!instance.toolbar || !instance.toolbar.container.classList.contains('overtype-toolbar')) throw new Error('Toolbar should be present and visible after showToolbar()');
+
+      // Hide toolbar
+      editor.hideToolbar();
+      instance = editor.getEditor();
+      if (instance.toolbar.container.classList.contains('overtype-toolbar')) throw new Error('Toolbar should not be visible after hideToolbar()');
+
+      container.removeChild(editor);
+      console.log('  ✅ Toolbar show/hide API works correctly');
+
+    }, 100); // Allow initialization
+  });
+
   
 }, 200);


### PR DESCRIPTION
The changes in this PR enable users of Overtype to programatically toggle the toolbar on and off, preserving the in memory representation to save redundant work.

This has been a challenge I've worked around while building my tool: [Waystation](https://waystation.aaronmyatt.com/) which uses Overtype as its editor.

You can explore my research and plan for this PR on Waystation itself! https://waystation.aaronmyatt.com/#!/?repo=panphora%2Fovertype

## [New public methods](/src/overtype.js#L1025)

Two new public methods are available on the editor instance to `showToolbar` or `hideToolbar`

src/overtype.js +1025
```text
   1020:     /**
   1021:      * reveal the toolbar if it is hidden
   1022:      * create it if it does not exist
   1023:      * @returns {void}
   1024:      */
=> 1025:     showToolbar(){
   1026:       if (this.toolbar) {
   1027:         this.toolbar.show();
   1028:       } else {
   1029:         this._createToolbar();
   1030:       }
```


## [Toolbar controls itself](/src/toolbar.js#L293)

The editor public methods delegate to the toolbar. I'd like feedback on whether adding/removing `.overtype-toolbar` is the wisest approach, or we can add a dedicated `.overtype-toolbar-hidden` class with a higher priority `display` style.

src/toolbar.js +293
```text
   288:   }
   289: 
   290:   /**
   291:    * Show the toolbar
   292:    */
=> 293:   show() {
   294:     if (this.container) {
   295:       this.container.classList.add('overtype-toolbar');
   296:       this.container.style.display = '';
   297:     }
   298:   }
```


## [The web component api has been extended similarly too](/src/overtype-webcomponent.js#L674)

src/overtype-webcomponent.js +674
```text
   669:    */
   670:   getEditor() {
   671:     return this._editor;
   672:   }
   673: 
=> 674:   showToolbar() {
   675:     if (this._editor) {
   676:       this._editor.showToolbar();
   677:     }
   678:   }
   679: 
```


## [Functionality is tested through the web component](/test/webcomponent.test.js#L472)

test/webcomponent.test.js +472
```text
   467:       }
   468:     }, 100);
   469:   });
   470: 
   471: 
=> 472:   runTest('Show / hide toolbar programmatically via API', () => {
   473:     const container = dom.window.document.getElementById('test-container');
   474:     const editor = dom.window.document.createElement('overtype-editor');
   475:     container.appendChild(editor);
   476: 
   477:     setTimeout(() => {
```



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds public methods to show and hide the toolbar, enabling programmatic control without destroying the instance. This lets integrations toggle the UI while preserving state and avoiding redundant work.

- **New Features**
  - OverType: showToolbar (creates if missing) and hideToolbar (hides if present).
  - Toolbar: show/hide toggle display and the .overtype-toolbar class to avoid CSS overrides.
  - Web component: showToolbar and hideToolbar delegate to the editor; tests cover visibility and state.

<sup>Written for commit 752594c69e6fffc5ea9e6b474a53ded772ebf56c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

