### PR TITLE
feat: re-export markdown-actions

### DIFF
--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -317,6 +317,26 @@ export type OverType = OverTypeInstance;
 // Module exports - default export is the constructor
 export default OverType;
 
+/** Re-exported markdown-actions. Useful for custom toolbar implementations */
+export const markdownActions: {
+  toggleBold(textarea: HTMLTextAreaElement): void;
+  toggleItalic(textarea: HTMLTextAreaElement): void;
+  toggleCode(textarea: HTMLTextAreaElement): void;
+  insertLink(textarea: HTMLTextAreaElement, options?: { url?: string; text?: string }): void;
+  toggleBulletList(textarea: HTMLTextAreaElement): void;
+  toggleNumberedList(textarea: HTMLTextAreaElement): void;
+  toggleQuote(textarea: HTMLTextAreaElement): void;
+  toggleTaskList(textarea: HTMLTextAreaElement): void;
+  insertHeader(textarea: HTMLTextAreaElement, level?: number, toggle?: boolean): void;
+  toggleH1(textarea: HTMLTextAreaElement): void;
+  toggleH2(textarea: HTMLTextAreaElement): void;
+  toggleH3(textarea: HTMLTextAreaElement): void;
+  getActiveFormats(textarea: HTMLTextAreaElement): string[];
+  hasFormat(textarea: HTMLTextAreaElement, format: string): boolean;
+  expandSelection(textarea: HTMLTextAreaElement, options?: object): void;
+  applyCustomFormat(textarea: HTMLTextAreaElement, format: object): void;
+};
+
 /**
  * Pre-defined toolbar buttons
  */

--- a/src/overtype.js
+++ b/src/overtype.js
@@ -1810,3 +1810,7 @@ export { OverType };
 
 // Export toolbar buttons for custom toolbar configurations
 export { toolbarButtons, defaultToolbarButtons } from './toolbar-buttons.js';
+
+// Re-export markdown-actions. Useful for custom toolbar implementations
+export * as markdownActions from 'markdown-actions';
+


### PR DESCRIPTION
As discussed in #105. (Closes #105.)

I didn't regenerate types and neither rebuilt the `dist` files to keep the diff clearer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-exported `markdown-actions` from the main module as `markdownActions` to make custom toolbar implementations easier. Added TypeScript definitions for these actions.

- **New Features**
  - Expose `markdownActions` via the package root (`export * as markdownActions from 'markdown-actions'`).
  - Include typed API for `markdownActions` in the generated types.

<sup>Written for commit 2d93a274143839f823acfcb8e5cd6ea70f15314b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

