### PR TITLE
Add link pasting

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OverType
 
-A lightweight markdown editor library with perfect WYSIWYG alignment using an invisible textarea overlay technique. Includes optional toolbar. ~117KB minified with all features.
+A lightweight markdown editor library with perfect WYSIWYG alignment using an invisible textarea overlay technique. Includes optional toolbar. ~119KB minified with all features.
 
 ## Live Examples
 
@@ -19,7 +19,7 @@ A lightweight markdown editor library with perfect WYSIWYG alignment using an in
 - ⌨️ **Keyboard shortcuts** - Common markdown shortcuts (Cmd/Ctrl+B for bold, etc.)
 - 📱 **Mobile optimized** - Responsive design with mobile-specific styles
 - 🔄 **DOM persistence aware** - Recovers from existing DOM (perfect for HyperClay and similar platforms)
-- 🚀 **Lightweight** - ~117KB minified
+- 🚀 **Lightweight** - ~119KB minified
 - 🎯 **Optional toolbar** - Clean, minimal toolbar with all essential formatting
 - ✨ **Smart shortcuts** - Keyboard shortcuts with selection preservation
 - 📝 **Smart list continuation** - GitHub-style automatic list continuation on Enter
@@ -35,7 +35,7 @@ We overlap an invisible textarea on top of styled output, giving the illusion of
 
 | Feature | OverType | HyperMD | Milkdown | TUI Editor | EasyMDE |
 |---------|----------|---------|----------|------------|---------|
-| **Size** | ~117KB | 364.02 KB | 344.51 KB | 560.99 KB | 323.69 KB |
+| **Size** | ~119KB | 364.02 KB | 344.51 KB | 560.99 KB | 323.69 KB |
 | **Dependencies** | Bundled | CodeMirror | ProseMirror + plugins | Multiple libs | CodeMirror |
 | **Setup** | Single file | Complex config | Build step required | Complex config | Moderate |
 | **Approach** | Invisible textarea | ContentEditable | ContentEditable | ContentEditable | CodeMirror |
@@ -332,6 +332,16 @@ const [editor] = new OverType('#editor', {
 
 See [examples/file-upload.html](website/examples/file-upload.html) for a complete working demo.
 
+### Link Paste
+
+When `linkPaste` is enabled, pasting a URL over selected text converts it into a Markdown link:
+
+```text
+Example + paste https://example.com -> [Example](https://example.com)
+```
+
+Pasting a URL without selected text keeps the paste native. Use Ctrl/Cmd+Shift+V to bypass link formatting for the next paste. Set `linkPaste: false` to keep URL pastes fully native.
+
 ### Custom Theme
 
 ```javascript
@@ -560,6 +570,9 @@ new OverType(target, options)
 
   // Smart lists
   smartLists: true,       // Enable GitHub-style list continuation on Enter
+
+  // Link paste
+  linkPaste: true,        // Convert pasted URLs into markdown links
 
   // Spellcheck
   spellcheck: false,      // Enable browser spellcheck (disabled by default)
@@ -914,7 +927,7 @@ Both put a real `required`/`name`/etc. attribute on the underlying `<textarea>`,
 
 Any object-valued option can also be passed as JSON (values starting with `{` or `[` are parsed; malformed JSON falls back to the raw string).
 
-**Supported:** `toolbar`, `theme`, `value`, `placeholder`, `autofocus`, `auto-resize`, `min-height`, `max-height`, `font-size`, `line-height`, `show-stats`, `smart-lists`, `show-active-line-raw`, `textarea-props` / `textarea-*`
+**Supported:** `toolbar`, `theme`, `value`, `placeholder`, `autofocus`, `auto-resize`, `min-height`, `max-height`, `font-size`, `line-height`, `show-stats`, `smart-lists`, `link-paste`, `show-active-line-raw`, `textarea-props` / `textarea-*`
 
 **Not supported (use JS):** `toolbarButtons`, `onChange`, `onKeydown`, `onFocus`, `onBlur`, `statsFormatter`, `codeHighlighter`, `colors`, `mobile`
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "build:prod": "npm test && npm run build",
     "dev": "http-server website -p 8080 -c-1",
     "watch": "node scripts/build.js --watch",
-    "test": "node test/overtype.test.js && node test/preview-mode.test.js && node test/links.test.js && node test/api-methods.test.js && node test/keyboard-accessibility.test.js && node test/comprehensive-alignment.test.js && node test/sanctuary-parsing.test.js && node test/mode-switching.test.js && node test/toolbar.test.js && node test/syntax-highlighting.test.js && node test/webcomponent.test.js && node test/custom-syntax.test.js && node test/auto-theme.test.js && npm run test:types",
+    "test": "node test/overtype.test.js && node test/preview-mode.test.js && node test/links.test.js && node test/link-paste.test.js && node test/api-methods.test.js && node test/keyboard-accessibility.test.js && node test/comprehensive-alignment.test.js && node test/sanctuary-parsing.test.js && node test/mode-switching.test.js && node test/toolbar.test.js && node test/syntax-highlighting.test.js && node test/webcomponent.test.js && node test/custom-syntax.test.js && node test/auto-theme.test.js && npm run test:types",
     "test:main": "node test/overtype.test.js",
     "test:preview": "node test/preview-mode.test.js",
     "test:links": "node test/links.test.js",

--- a/scripts/generate-types.js
+++ b/scripts/generate-types.js
@@ -220,6 +220,7 @@ export interface Options {
   toolbar?: boolean;
   toolbarButtons?: ToolbarButton[];  // Custom toolbar button configuration
   smartLists?: boolean;       // v1.2.3+ Smart list continuation
+  linkPaste?: boolean;        // Convert pasted URLs into markdown links
   spellcheck?: boolean;       // Browser spellcheck (default: false)
   statsFormatter?: (stats: Stats) => string;
   codeHighlighter?: ((code: string, language: string) => string) | null;  // Per-instance code highlighter

--- a/src/overtype-webcomponent.js
+++ b/src/overtype-webcomponent.js
@@ -15,7 +15,7 @@ const DEFAULT_PLACEHOLDER = 'Start typing...';
 const OBSERVED_ATTRIBUTES = [
   'value', 'theme', 'toolbar', 'height', 'min-height', 'max-height', 
   'placeholder', 'font-size', 'line-height', 'padding', 'auto-resize', 
-  'autofocus', 'show-stats', 'smart-lists', 'readonly', 'spellcheck'
+  'autofocus', 'show-stats', 'smart-lists', 'link-paste', 'readonly', 'spellcheck'
 ];
 
 /**
@@ -262,6 +262,7 @@ class OverTypeEditor extends HTMLElement {
       autoResize: this.hasAttribute('auto-resize'),
       showStats: this.hasAttribute('show-stats'),
       smartLists: !this.hasAttribute('smart-lists') || this.getAttribute('smart-lists') !== 'false',
+      linkPaste: !this.hasAttribute('link-paste') || this.getAttribute('link-paste') !== 'false',
       spellcheck: this.hasAttribute('spellcheck') && this.getAttribute('spellcheck') !== 'false',
       onChange: this._handleChange,
       onKeydown: this._handleKeydown,
@@ -388,6 +389,13 @@ class OverTypeEditor extends HTMLElement {
       case 'smart-lists': {
         const newSmartLists = !this.hasAttribute('smart-lists') || this.getAttribute('smart-lists') !== 'false';
         if (!!this._editor.options.smartLists === !!newSmartLists) return;
+        this._reinitializeEditor();
+        break;
+      }
+
+      case 'link-paste': {
+        const newLinkPaste = !this.hasAttribute('link-paste') || this.getAttribute('link-paste') !== 'false';
+        if (!!this._editor.options.linkPaste === !!newLinkPaste) return;
         this._reinitializeEditor();
         break;
       }

--- a/src/overtype.d.ts
+++ b/src/overtype.d.ts
@@ -128,6 +128,7 @@ export interface Options {
   toolbar?: boolean;
   toolbarButtons?: ToolbarButton[];  // Custom toolbar button configuration
   smartLists?: boolean;       // v1.2.3+ Smart list continuation
+  linkPaste?: boolean;        // Convert pasted URLs into markdown links
   spellcheck?: boolean;       // Browser spellcheck (default: false)
   statsFormatter?: (stats: Stats) => string;
   codeHighlighter?: ((code: string, language: string) => string) | null;  // Per-instance code highlighter

--- a/src/overtype.js
+++ b/src/overtype.js
@@ -4,7 +4,7 @@
  * @license MIT
  */
 
-import { MarkdownParser } from './parser.js';
+import { MarkdownParser, safeUrlPrefixes } from './parser.js';
 import { ShortcutsManager } from './shortcuts.js';
 import { generateStyles } from './styles.js';
 import { getTheme, mergeTheme, solar, themeToCSSVars, resolveAutoTheme } from './themes.js';
@@ -245,6 +245,7 @@ class OverType {
         toolbarButtons: null,  // Defaults to defaultToolbarButtons if toolbar: true
         statsFormatter: null,
         smartLists: true,  // Enable smart list continuation
+        linkPaste: true,  // Convert pasted URLs into markdown links
         codeHighlighter: null,  // Per-instance code highlighter
         spellcheck: false,  // Browser spellcheck (disabled by default)
         transformLinkUrl: null  // Transform URLs shown/opened in the link tooltip
@@ -646,8 +647,123 @@ class OverType {
         this._destroyFileUpload();
       }
 
+      // Setup or remove link paste
+      if (this.options.linkPaste && !this.linkPasteInitialized) {
+        this._initLinkPaste();
+      } else if (!this.options.linkPaste && this.linkPasteInitialized) {
+        this._destroyLinkPaste();
+      }
+
       // Update preview with initial content
       this.updatePreview();
+    }
+
+    _initLinkPaste() {
+      this._pasteAsPlainText = false;
+      this._pasteAsPlainTextTimeout = null;
+      this._boundHandleLinkPaste = this._handleLinkPaste.bind(this);
+      this._boundHandleLinkPasteKeydown = this._handleLinkPasteKeydown.bind(this);
+
+      this.textarea.addEventListener('paste', this._boundHandleLinkPaste);
+      this.textarea.addEventListener('keydown', this._boundHandleLinkPasteKeydown);
+
+      this.linkPasteInitialized = true;
+    }
+
+    _handleLinkPaste(event) {
+      if (this._pasteAsPlainText) {
+        this._clearPasteAsPlainText();
+        return;
+      }
+
+      if (
+        event.defaultPrevented ||
+        !this._canEditTextarea() ||
+        this.textarea.selectionStart === this.textarea.selectionEnd ||
+        event.clipboardData?.files?.length
+      ) {
+        return;
+      }
+
+      const pastedText = event.clipboardData?.getData('text/plain').trim();
+
+      if (!pastedText || !this._isLinkPasteUrl(pastedText)) {
+        return;
+      }
+
+      event.preventDefault();
+      this._insertLinkAtSelection(pastedText);
+    }
+
+    _handleLinkPasteKeydown(event) {
+      if (
+        this._isModifierKeyPressed(event) &&
+        event.shiftKey &&
+        event.key.toLowerCase() === 'v'
+      ) {
+        this._allowNextPasteAsPlainText();
+      }
+    }
+
+    _allowNextPasteAsPlainText() {
+      this._pasteAsPlainText = true;
+
+      if (this._pasteAsPlainTextTimeout) {
+        clearTimeout(this._pasteAsPlainTextTimeout);
+      }
+
+      this._pasteAsPlainTextTimeout = setTimeout(() => {
+        this._pasteAsPlainText = false;
+        this._pasteAsPlainTextTimeout = null;
+      }, 1000);
+    }
+
+    _clearPasteAsPlainText() {
+      this._pasteAsPlainText = false;
+
+      if (this._pasteAsPlainTextTimeout) {
+        clearTimeout(this._pasteAsPlainTextTimeout);
+        this._pasteAsPlainTextTimeout = null;
+      }
+    }
+
+    _insertLinkAtSelection(url) {
+      const { selectionStart, selectionEnd, value } = this.textarea;
+      const selectedText = value.slice(selectionStart, selectionEnd);
+      const markdown = `[${selectedText}](${url})`;
+
+      this.textarea.setRangeText(markdown, selectionStart, selectionEnd, 'end');
+
+      this.textarea.dispatchEvent(new Event('input', { bubbles: true }));
+    }
+
+    _isLinkPasteUrl(value) {
+      const trimmed = value.trim();
+      const lower = trimmed.toLowerCase();
+
+      try {
+        new URL(trimmed);
+
+        return safeUrlPrefixes.some(prefix => lower.startsWith(prefix));
+      } catch (_) {
+        return false;
+      }
+    }
+
+    _isModifierKeyPressed(event) {
+      const isMac = navigator.platform.toLowerCase().includes('mac');
+
+      return isMac ? event.metaKey : event.ctrlKey;
+    }
+
+    _destroyLinkPaste() {
+      this._clearPasteAsPlainText();
+
+      this.textarea.removeEventListener('paste', this._boundHandleLinkPaste);
+      this.textarea.removeEventListener('keydown', this._boundHandleLinkPasteKeydown);
+      this._boundHandleLinkPaste = null;
+      this._boundHandleLinkPasteKeydown = null;
+      this.linkPasteInitialized = false;
     }
 
     _initFileUpload() {
@@ -1643,6 +1759,9 @@ class OverType {
 
       if (this.fileUploadInitialized) {
         this._destroyFileUpload();
+      }
+      if (this.linkPasteInitialized) {
+        this._destroyLinkPaste();
       }
 
       // Remove instance reference

--- a/src/parser.js
+++ b/src/parser.js
@@ -1,3 +1,13 @@
+export const safeUrlPrefixes = [
+  'http://',
+  'https://',
+  'mailto:',
+  'ftp://',
+  'ftps://',
+  'tel:',
+  'sms:'
+];
+
 /**
  * MarkdownParser - Parses markdown into HTML while preserving character alignment
  *
@@ -243,17 +253,8 @@ export class MarkdownParser {
     const trimmed = url.trim();
     const lower = trimmed.toLowerCase();
 
-    // Allow safe protocols
-    const safeProtocols = [
-      'http://',
-      'https://',
-      'mailto:',
-      'ftp://',
-      'ftps://'
-    ];
-
     // Check if URL starts with a safe protocol
-    const hasSafeProtocol = safeProtocols.some(protocol => lower.startsWith(protocol));
+    const hasSafeProtocol = safeUrlPrefixes.some(prefix => lower.startsWith(prefix));
 
     // Allow relative URLs (starting with / or # or no protocol)
     const isRelative = trimmed.startsWith('/') ||

--- a/test/link-paste.test.js
+++ b/test/link-paste.test.js
@@ -1,0 +1,290 @@
+/**
+ * Link paste tests for OverType.
+ */
+
+import { JSDOM } from 'jsdom';
+import { OverType } from '../src/overtype.js';
+import { MarkdownParser } from '../src/parser.js';
+
+const dom = new JSDOM('<!DOCTYPE html><html><body><div id="editor"></div></body></html>', {
+  pretendToBeVisual: true
+});
+
+global.window = dom.window;
+global.document = dom.window.document;
+global.Element = dom.window.Element;
+global.Node = dom.window.Node;
+global.NodeList = dom.window.NodeList;
+global.HTMLElement = dom.window.HTMLElement;
+global.Event = dom.window.Event;
+global.CustomEvent = dom.window.CustomEvent;
+global.KeyboardEvent = dom.window.KeyboardEvent;
+global.customElements = dom.window.customElements;
+global.CSS = { supports: () => false };
+global.performance = { now: () => Date.now() };
+global.requestAnimationFrame = (callback) => setTimeout(callback, 0);
+global.cancelAnimationFrame = (id) => clearTimeout(id);
+
+Object.defineProperty(global, 'navigator', {
+  configurable: true,
+  value: dom.window.navigator
+});
+
+Object.defineProperty(dom.window.navigator, 'platform', {
+  configurable: true,
+  value: 'Win32'
+});
+
+if (!document.execCommand) {
+  document.execCommand = () => false;
+}
+
+let passed = 0;
+let failed = 0;
+
+function assert(condition, testName, message) {
+  if (condition) {
+    passed++;
+    console.log(`✓ ${testName}`);
+    return;
+  }
+
+  failed++;
+  console.error(`✗ ${testName}: ${message}`);
+}
+
+function resetDOM(markup = '<div id="editor"></div>') {
+  document.body.innerHTML = markup;
+}
+
+function createEditor(options = {}) {
+  resetDOM();
+
+  return new OverType('#editor', options)[0];
+}
+
+function dispatchPasteTo(target, text, { files = [] } = {}) {
+  const event = new window.Event('paste', {
+    bubbles: true,
+    cancelable: true
+  });
+
+  Object.defineProperty(event, 'clipboardData', {
+    value: {
+      files,
+      getData(type) {
+        return type === 'text/plain' ? text : '';
+      }
+    }
+  });
+
+  target.dispatchEvent(event);
+
+  return event;
+}
+
+function dispatchPaste(editor, text, options = {}) {
+  return dispatchPasteTo(editor.textarea, text, options);
+}
+
+function dispatchPlainPasteShortcut(editor) {
+  const event = new window.KeyboardEvent('keydown', {
+    key: 'v',
+    ctrlKey: true,
+    shiftKey: true,
+    bubbles: true,
+    cancelable: true
+  });
+
+  editor.textarea.dispatchEvent(event);
+
+  return event;
+}
+
+function selectText(editor, text) {
+  const start = editor.getValue().indexOf(text);
+  editor.textarea.setSelectionRange(start, start + text.length);
+}
+
+console.log('🔗 Running Link Paste Tests...\n');
+console.log('━'.repeat(50));
+
+console.log('\n📝 URL paste behavior\n');
+
+(() => {
+  const editor = createEditor({ value: 'See Example today' });
+  selectText(editor, 'Example');
+
+  const event = dispatchPaste(editor, ' https://example.com ');
+
+  assert(event.defaultPrevented, 'Selected URL paste is handled', 'Expected URL paste to be prevented');
+  assert(
+    editor.getValue() === 'See [Example](https://example.com) today',
+    'Selected URL paste wraps selected text',
+    `Unexpected value: ${editor.getValue()}`
+  );
+})();
+
+(() => {
+  const editor = createEditor({ value: 'Visit ' });
+  editor.textarea.setSelectionRange(6, 6);
+
+  const event = dispatchPaste(editor, 'https://example.com');
+
+  assert(!event.defaultPrevented, 'Collapsed URL paste is native', 'Expected URL paste to stay native');
+  assert(
+    editor.getValue() === 'Visit ',
+    'Collapsed URL paste does not edit content in tests',
+    `Unexpected value: ${editor.getValue()}`
+  );
+})();
+
+(() => {
+  const editor = createEditor({ value: 'Example' });
+  selectText(editor, 'Example');
+  dispatchPlainPasteShortcut(editor);
+
+  const bypassedEvent = dispatchPaste(editor, 'https://example.com');
+  const handledEvent = dispatchPaste(editor, 'https://example.com');
+
+  assert(!bypassedEvent.defaultPrevented, 'Ctrl+Shift+V bypasses link paste once', 'Expected first paste to stay native');
+  assert(handledEvent.defaultPrevented, 'Ctrl+Shift+V bypass is cleared after one paste', 'Expected second paste to be handled');
+})();
+
+console.log('\n🚫 Non-link paste behavior\n');
+
+(() => {
+  const editor = createEditor({ value: 'Example' });
+  selectText(editor, 'Example');
+
+  const event = dispatchPaste(editor, 'javascript:alert(1)');
+
+  assert(!event.defaultPrevented, 'Dangerous scheme paste is native', 'Expected javascript: paste to remain native');
+  assert(editor.getValue() === 'Example', 'Dangerous scheme paste does not edit content', 'Expected content to remain unchanged');
+})();
+
+(() => {
+  const editor = createEditor({ value: 'Example' });
+  selectText(editor, 'Example');
+
+  const relativeEvent = dispatchPaste(editor, '/relative/path');
+  const bareDomainEvent = dispatchPaste(editor, 'example.com');
+
+  assert(!relativeEvent.defaultPrevented, 'Relative URL paste is native', 'Expected relative URL paste to remain native');
+  assert(!bareDomainEvent.defaultPrevented, 'Bare domain paste is native', 'Expected bare domain paste to remain native');
+  assert(editor.getValue() === 'Example', 'Native non-link pastes do not edit content in tests', 'Expected content unchanged');
+})();
+
+(() => {
+  const editor = createEditor({ value: 'Example', linkPaste: false });
+  selectText(editor, 'Example');
+
+  const event = dispatchPaste(editor, 'https://example.com');
+
+  assert(!event.defaultPrevented, 'linkPaste false disables URL handling', 'Expected paste to stay native');
+  assert(editor.getValue() === 'Example', 'linkPaste false does not edit content', 'Expected content unchanged');
+})();
+
+console.log('\n📎 File paste precedence\n');
+
+(() => {
+  const file = { name: 'photo.png', size: 100, type: 'image/png' };
+  const editor = createEditor({
+    value: 'Example',
+    fileUpload: {
+      enabled: true,
+      onInsertFile: async () => '![photo.png](/uploads/photo.png)'
+    }
+  });
+
+  selectText(editor, 'Example');
+
+  const event = dispatchPaste(editor, 'https://example.com', { files: [file] });
+
+  assert(event.defaultPrevented, 'File paste is handled by file upload', 'Expected file upload to prevent paste');
+  assert(
+    editor.getValue().includes('Uploading photo.png'),
+    'File paste does not become a markdown link',
+    `Expected upload placeholder. Got ${editor.getValue()}`
+  );
+})();
+
+console.log('\n🔁 Lifecycle and declarative options\n');
+
+(() => {
+  const editor = createEditor({ value: 'Example' });
+
+  editor.reinit({ linkPaste: false });
+  selectText(editor, 'Example');
+  const disabledEvent = dispatchPaste(editor, 'https://example.com');
+
+  editor.reinit({ linkPaste: true });
+  selectText(editor, 'Example');
+  const enabledEvent = dispatchPaste(editor, 'https://example.com');
+
+  assert(!disabledEvent.defaultPrevented, 'reinit can disable link paste', 'Expected disabled paste to stay native');
+  assert(enabledEvent.defaultPrevented, 'reinit can enable link paste', 'Expected enabled paste to be handled');
+})();
+
+(() => {
+  const editor = createEditor({ value: 'Example' });
+  selectText(editor, 'Example');
+  const textarea = editor.textarea;
+
+  editor.destroy();
+
+  const event = dispatchPasteTo(textarea, 'https://example.com');
+
+  assert(!event.defaultPrevented, 'destroy removes link paste listener', 'Expected detached textarea paste to stay native');
+  assert(textarea.value === 'Example', 'destroyed listener does not edit detached textarea', 'Expected content unchanged');
+})();
+
+(() => {
+  resetDOM('<div class="editor" data-ot-link-paste="false">Example</div>');
+  const editor = OverType.initFromData('.editor')[0];
+  selectText(editor, 'Example');
+
+  const event = dispatchPaste(editor, 'https://example.com');
+
+  assert(editor.options.linkPaste === false, 'data-ot-link-paste false maps to option', 'Expected option to be false');
+  assert(!event.defaultPrevented, 'data-ot-link-paste false disables behavior', 'Expected paste to stay native');
+})();
+
+await import('../src/overtype-webcomponent.js');
+
+(() => {
+  resetDOM('<overtype-editor id="web-component-editor" link-paste="false">Example</overtype-editor>');
+  const component = document.getElementById('web-component-editor');
+  const editor = component.getEditor();
+
+  selectText(editor, 'Example');
+  const event = dispatchPaste(editor, 'https://example.com');
+
+  assert(editor.options.linkPaste === false, 'web component link-paste false maps to option', 'Expected option to be false');
+  assert(!event.defaultPrevented, 'web component link-paste false disables behavior', 'Expected paste to stay native');
+})();
+
+console.log('\n🧼 URL sanitizer alignment\n');
+
+(() => {
+  const tel = MarkdownParser.parse('[Call](tel:+123456789)');
+  const sms = MarkdownParser.parse('[Text](sms:+123456789)');
+
+  assert(tel.includes('href="tel:+123456789"'), 'tel links render as safe hrefs', `Unexpected tel render: ${tel}`);
+  assert(sms.includes('href="sms:+123456789"'), 'sms links render as safe hrefs', `Unexpected sms render: ${sms}`);
+})();
+
+console.log('\n' + '━'.repeat(50));
+console.log('\n📊 Test Results Summary\n');
+console.log(`✅ Passed: ${passed}`);
+console.log(`❌ Failed: ${failed}`);
+console.log(`📈 Total:  ${passed + failed}`);
+console.log(`🎯 Success Rate: ${((passed / (passed + failed)) * 100).toFixed(1)}%`);
+
+if (failed > 0) {
+  console.error(`\n❌ ${failed} test(s) failed!`);
+  process.exit(1);
+}
+
+console.log('\n✅ All tests passed!');
+process.exit(0);

--- a/test/test-types.ts
+++ b/test/test-types.ts
@@ -42,6 +42,7 @@ const editorsWithOptions: OverTypeInstance[] = new OverType('#editor', {
   showActiveLineRaw: true,
   showStats: true,
   toolbar: true,
+  linkPaste: true,
   statsFormatter: (stats: Stats) => `${stats.words} words, ${stats.chars} chars`,
 
   // Callbacks


### PR DESCRIPTION
Adds default-on link paste support, which is a useful feature GitHub's markdown editor has.

Pasting a safe absolute URL over selected text now wraps the selection as a Markdown link.

The behavior can be disabled with `linkPaste: false`, `data-ot-link-paste="false"`, or web component `link-paste="false"`. Ctrl/Cmd+Shift+V bypasses formatting for the next paste. The URL allowlist is shared with the parser sanitizer, including `tel:` and `sms:` support.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds default-on link paste: pasting a safe URL over selected text wraps it as a Markdown link, matching GitHub’s editor. Uses the parser’s safe URL allowlist (now includes `tel:` and `sms:`) and supports a one-time bypass with Ctrl/Cmd+Shift+V.

- **New Features**
  - Wraps selected text on paste of safe absolute URLs; no selection keeps the paste native.
  - Disable via `linkPaste: false`, `data-ot-link-paste="false"`, or web component `link-paste="false"`; supports reinit and attribute updates.
  - Shares sanitizer allowlist with the parser, including `tel:` and `sms:`.
  - File pastes still go to file upload (take precedence over link wrapping).
  - Updated docs, types, and tests (`test/link-paste.test.js`); README size updated to ~119KB; test script includes the new test.

<sup>Written for commit a1e095cb70c97cef1ee2c0fb227bc73ff1eec1a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/panphora/overtype/pull/117?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

