### PR TITLE
SVG icons in buttons should be decorative

### DIFF
--- a/src/toolbar.js
+++ b/src/toolbar.js
@@ -286,7 +286,15 @@ export class Toolbar {
       .replace(/\son\w+\s*=\s*["'][^"']*["']/gi, '')
       .replace(/\son\w+\s*=\s*[^\s>]*/gi, '');
 
-    return cleaned;
+    const template = document.createElement('template');
+    template.innerHTML = cleaned;
+
+    template.content.querySelectorAll('svg').forEach(icon => {
+      icon.setAttribute('aria-hidden', 'true');
+      icon.setAttribute('focusable', 'false');
+    });
+
+    return template.innerHTML;
   }
 
   /**

--- a/test/toolbar.test.js
+++ b/test/toolbar.test.js
@@ -121,6 +121,13 @@ console.log('━'.repeat(50));
     'Toolbar item semantics',
     'Expected toggle state only on toggle buttons and separators outside tab order'
   );
+  assert(
+    Array.from(toolbar.querySelectorAll('.overtype-toolbar-button svg')).every(icon =>
+      icon.getAttribute('aria-hidden') === 'true' && icon.getAttribute('focusable') === 'false'
+    ),
+    'Toolbar icons are decorative',
+    'Expected every toolbar SVG icon to be hidden from assistive technology and removed from SVG focus'
+  );
 
   editor.destroy();
 })();


### PR DESCRIPTION
A small accessibility improvement, SVG icons within the toolbar buttons should be hidden from assistive technologies.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Marks SVG icons in toolbar buttons as decorative by setting aria-hidden="true" and focusable="false" during sanitization, so screen readers ignore them and they aren’t focusable. Adds a test to enforce these attributes on all toolbar button SVGs.

<sup>Written for commit dd8a9c673e090ea6c2cecd342467143c8a2022ca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/panphora/overtype/pull/118?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

